### PR TITLE
Fix load order sorting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ function loadOrderPrefix(api: types.IExtensionApi, mod: types.IMod): string {
   const gameId = mod.attributes.downloadGame;
   if (!gameId) return 'ZZZZ-';
   const profile = selectors.lastActiveProfileForGame(state, gameId);
-  const loadOrder = util.getSafe(state, ['persistent', 'loadOrder', profile.id], {});
+  const loadOrder = util.getSafe(state, ['persistent', 'loadOrder', profile], {});
   const loKeys = Object.keys(loadOrder);
   const pos = loKeys.indexOf(mod.id);
   if (pos === -1) {


### PR DESCRIPTION
This patch fixes prefixes in load order

Reproduction (Ready Or Not - Vortex Extension):
1. Make sorting of mods
2. Open the ~mods folder
3. The prefix of all mods will be 'ZZZZ-'
4. Apply the patch and restart Vortex
5. Sort the mods
6. Open the ~mods folder
3. The mods prefix will be correct