### PR TITLE
Allow overriding 'loadOrderPrefix' function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unreal-engine-game-library",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A library of generic functions for setting up a Vortex extension for an Unreal Engine game.",
   "main": "./out/index.js",
   "repository": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,12 @@ function main(context: types.IExtensionContext) {
     () => Promise.resolve(false), 
     {
       name: 'Unreal Engine Pak Sortable Mod',
-      mergeMods: mod => loadOrderPrefix(context.api, mod) + mod.id
+      mergeMods: mod => {
+          const gameId = mod.attributes.downloadGame;
+          const game = util.getGame(gameId);
+          const loadOrderPrefixFunc = util.getSafe(game, ['details', 'unrealEngine', 'loadOrderPrefixFunc'], loadOrderPrefix);
+          return loadOrderPrefixFunc(context, mod) + mod.id;
+      }
     }
   );
 
@@ -157,7 +162,8 @@ function makePrefix(input) {
   return util.pad(res, 'A', 3);
 }
 
-function loadOrderPrefix(api: types.IExtensionApi, mod: types.IMod): string {
+function loadOrderPrefix(context: types.IExtensionContext, mod: types.IMod): string {
+  const api = context.api;
   const state = api.getState();
   const gameId = mod.attributes.downloadGame;
   if (!gameId) return 'ZZZZ-';


### PR DESCRIPTION
* Third party developers can use File Based Load Order API (FBLO API) to sort mods and the 'loadOrder' field may contain a different structure than ours, which breaks prefix creation when using FBLO API. Allow overriding the 'loadOrderPrefix' function to control prefix creation.